### PR TITLE
fix: change title color for platforms for emphasis

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -123,7 +123,7 @@
                 </a>
               </div>
               <div class="p-2 w-100 my-auto">
-                <h5 class="mb-3">Virtual Events</h5>
+                <h5 class="mb-3 smev-card-heading">Virtual Events</h5>
                 <p>Live-streamed and pre-recorded webinars, workshops and walkthroughs.</p>
               </div>
             </div>
@@ -135,7 +135,7 @@
                 </a>
               </div>
               <div class="p-2 w-100 my-auto">
-                <h5 class="mb-3">Industry 4.0 Discussion</h5>
+                <h5 class="mb-3 smev-card-heading">Industry 4.0 Discussion</h5>
                 <p><strong>BETA</strong> Advanced topics, insightful posts, Ask-Me-Anythings and Q&As - discuss it all here.</p>
               </div>
             </div>
@@ -147,7 +147,7 @@
                 </a>
               </div>
               <div class="p-2 w-100 my-auto">
-                <h5 class="mb-3">Instant Chat</h5>
+                <h5 class="mb-3 smev-card-heading">Instant Chat</h5>
                 <p><strong>BETA</strong> Realtime, always-on interaction with the community.</p>
               </div>
             </div>
@@ -159,7 +159,7 @@
                 </a>
               </div>
               <div class="p-2 w-100 my-auto">
-                <h5 class="mb-3">Open Source Work</h5>
+                <h5 class="mb-3 smev-card-heading">Open Source Work</h5>
                 <p>We love open-source. Take a look at our current software/hardware projects. You can get involved too!</p>
               </div>
             </div>

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -159,6 +159,10 @@ $border-color: #c0bfc0 !default;
   height: 80px;
 }
 
+.smev-card-heading {
+  color: $blue;
+}
+
 .sme-card-logo {
   width: 100px;
 }


### PR DESCRIPTION
Changed the text color for each platform listed in the
Engagement Platforms card for visual emphasis.

Closes #8